### PR TITLE
add upload configurations on php.ini

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# directories
+/src
+/logs
+/data
+/ssl
+
+
+
+#ides
+.vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN a2enmod ssl && a2enmod rewrite
 RUN mkdir -p /etc/apache2/ssl
 RUN mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
 
-COPY 90-xdebug.ini "${PHP_INI_DIR}/conf.d"
+COPY ./php/*.ini "${PHP_INI_DIR}/conf.d" 
 RUN pecl install xdebug
 RUN docker-php-ext-enable xdebug
 
@@ -13,3 +13,4 @@ COPY ./apache/000-default.conf /etc/apache2/sites-available/000-default.conf
 
 EXPOSE 80
 EXPOSE 443
+EXPOSE 9003

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     ports:
       - 80:80
       - 443:443
+      - 9003:9003
     environment:
       WORDPRESS_DB_HOST: mysql
       WORDPRESS_DB_USER: exampleuser
@@ -41,17 +42,6 @@ services:
       - 3306:3306
     volumes:
       - ./data/db:/var/lib/mysql:delegated
-    networks:
-      - wordpress-net
-
-  adminer:
-    image: adminer
-    restart: always
-    container_name: wordpress-adminer
-    ports:
-        - 81:8080
-    links:
-        - mysql
     networks:
       - wordpress-net
 

--- a/php/uploads.ini
+++ b/php/uploads.ini
@@ -1,0 +1,5 @@
+file_uploads = On
+memory_limit = 128M
+upload_max_filesize = 256M
+post_max_size = 128M
+max_execution_time = 600

--- a/php/xdebug.ini
+++ b/php/xdebug.ini
@@ -1,0 +1,8 @@
+zend_extension=xdebug.so
+xdebug.mode=debug
+xdebug.start_with_request=yes
+xdebug.client_port=9003
+xdebug.discover_client_host=0
+xdebug.client_host='host.docker.internal'
+xdebug.log = /tmp/xdebug.log
+xdebug.idekey = VSCODE

--- a/xdebug.ini
+++ b/xdebug.ini
@@ -1,8 +1,0 @@
-zend_extension=xdebug.so
-xdebug.mode=debug
-xdebug.start_with_request=yes
-xdebug.client_port=9003
-xdebug.discover_client_host=0
-xdebug.client_host='host.docker.internal'
-xdebug.log = /tmp/xdebug.log
-xdebug.idekey = VSCODE


### PR DESCRIPTION
adiciona configurações para o upload de arquivos:

* file_uploads = On
* memory_limit = 128M
* upload_max_filesize = 256M
* post_max_size = 128M
* max_execution_time = 600

E muda o nome do arquivo do xdebug para ficar igual ao do docker file